### PR TITLE
Fix duplicated "title" property in statistics.json

### DIFF
--- a/schemas/Statistics/Statistics.json
+++ b/schemas/Statistics/Statistics.json
@@ -1161,7 +1161,7 @@
       "required" : [ "CQC_Time_Played", "CQC_KD", "CQC_Kills", "CQC_WL" ]
     },
     "Squadron": {
-      "title" : "CQC",
+      "title" : "Squadron",
       "type" : "object",
       "properties" : {
         "Squadron_Bank_Credits_Deposited": {


### PR DESCRIPTION
Hello there! I have been using your awesome schema files to generate some structs in rust for a project of mine, and I believe I have run into a small error in one of the schema files. 