### PR TITLE
fix: adjust fragment pointers to be absolute

### DIFF
--- a/schemas/Backpack/Backpack.json
+++ b/schemas/Backpack/Backpack.json
@@ -10,7 +10,7 @@
       "type" : "array",
       "default": null,
       "items" : {
-        "$ref": "../common/ShipLockerBackpack.json#definitions/Item"
+        "$ref": "../common/ShipLockerBackpack.json#/definitions/Item"
       }
     },
     "Components" : {
@@ -18,7 +18,7 @@
       "type" : "array",
       "default": null,
       "items" : {
-        "$ref": "../common/ShipLockerBackpack.json#definitions/Component"
+        "$ref": "../common/ShipLockerBackpack.json#/definitions/Component"
       }
     },
     "Consumables" : {
@@ -26,7 +26,7 @@
       "type" : "array",
       "default": null,
       "items" : {
-        "$ref": "../common/ShipLockerBackpack.json#definitions/Consumable"
+        "$ref": "../common/ShipLockerBackpack.json#/definitions/Consumable"
       }
     },
     "Data" : {
@@ -34,7 +34,7 @@
       "type" : "array",
       "default": null,
       "items" : {
-        "$ref": "../common/ShipLockerBackpack.json#definitions/Data"
+        "$ref": "../common/ShipLockerBackpack.json#/definitions/Data"
       }
     }
   },

--- a/schemas/ShipLocker/ShipLocker.json
+++ b/schemas/ShipLocker/ShipLocker.json
@@ -10,7 +10,7 @@
       "type" : "array",
       "default": null,
       "items" : {
-        "$ref": "../common/ShipLockerBackpack.json#definitions/Item"
+        "$ref": "../common/ShipLockerBackpack.json#/definitions/Item"
       }
     },
     "Components" : {
@@ -18,7 +18,7 @@
       "type" : "array",
       "default": null,
       "items" : {
-        "$ref": "../common/ShipLockerBackpack.json#definitions/Component"
+        "$ref": "../common/ShipLockerBackpack.json#/definitions/Component"
       }
     },
     "Consumables" : {
@@ -26,7 +26,7 @@
       "type" : "array",
       "default": null,
       "items" : {
-        "$ref": "../common/ShipLockerBackpack.json#definitions/Consumable"
+        "$ref": "../common/ShipLockerBackpack.json#/definitions/Consumable"
       }
     },
     "Data" : {
@@ -34,7 +34,7 @@
       "type" : "array",
       "default": null,
       "items" : {
-        "$ref": "../common/ShipLockerBackpack.json#definitions/Data"
+        "$ref": "../common/ShipLockerBackpack.json#/definitions/Data"
       }
     }
   },


### PR DESCRIPTION
JSON Schema makes use of JSON Pointers to reference parts of a Schema. Right now, this is incorrectly labelled for the 2 files which reference the Ship Locker placed under the `common` Section


> A JSON Pointer is a Unicode string (see [[RFC4627], Section 3](https://datatracker.ietf.org/doc/html/rfc4627#section-3))
   containing a sequence of zero or more reference tokens, **each prefixed
   by a '/' (%x2F) character**. — https://datatracker.ietf.org/doc/html/rfc6901#section-3

The 2020-12 Spec references the RFC mentioned above for JSON Pointers:
> The use of JSON Pointers as URI fragment identifiers is described in [RFC 6901](https://json-schema.org/draft/2020-12/json-schema-core#RFC6901) [[RFC6901](https://json-schema.org/draft/2020-12/json-schema-core#RFC6901)]. For "application/schema+json", which supports two fragment identifier syntaxes, fragment identifiers matching the JSON Pointer syntax, including the empty string, MUST be interpreted as JSON Pointer fragment identifiers. — https://json-schema.org/draft/2020-12/json-schema-core#section-5-3
